### PR TITLE
Bugfix - changing beta angle does not change the sheets

### DIFF
--- a/ldrb/ldrb.py
+++ b/ldrb/ldrb.py
@@ -63,7 +63,7 @@ def orient(Q, alpha, beta):
         ]
     )
 
-    C = np.dot(Q.real, A, B)
+    C = np.dot(Q.real, A).dot(B)
     return C
 
 

--- a/tests/test_ldrb.py
+++ b/tests/test_ldrb.py
@@ -48,7 +48,7 @@ def lv_mesh():
     return ldrb.create_lv_mesh().mesh
 
 
-def test_lv_angles():
+def test_lv_angles_alpha():
 
     data = {}
     eps = 0
@@ -66,13 +66,14 @@ def test_lv_angles():
     sheet_normal = np.zeros(9)
     sheet_normal[::3] = -1
 
-    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=90, alpha_epi_lv=-90, **data)
+    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=90, alpha_epi_lv=-90, beta_endo_lv=0, beta_epi_lv=0, **data)
+
     assert norm(fib.fiber[:3] - np.array([0, 1, 0])) < tol
     assert norm(fib.fiber[3:6]-np.array([0, 1 / np.sqrt(2), 1 / np.sqrt(2)])) < tol
     assert norm(fib.fiber[6:] - np.array([0, -1, 0])) < tol
     assert norm(fib.sheet_normal - sheet_normal) < tol
 
-    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=-90, alpha_epi_lv=90, **data)
+    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=-90, alpha_epi_lv=90, beta_endo_lv=0, beta_epi_lv=0,**data)
     assert norm(fib.fiber[:3] - np.array([0, -1, 0])) < tol
     assert norm(fib.fiber[3:6]-np.array([0, -1 / np.sqrt(2), 1 / np.sqrt(2)])) < tol
     assert norm(fib.fiber[6:] - np.array([0, 1, 0])) < tol
@@ -80,7 +81,7 @@ def test_lv_angles():
     
     for alpha in [60, -60]:
         a = np.radians(alpha)
-        fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=alpha, alpha_epi_lv=-alpha, **data)
+        fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=alpha, alpha_epi_lv=-alpha, beta_endo_lv=0, beta_epi_lv=0,**data)
         assert norm(fib.fiber[:3] - np.array([0, np.sin(a), np.cos(a)])) < tol
         assert norm(fib.fiber[3:6]- np.sign(alpha) * np.array([0, np.cos(a), np.sin(a)])) < tol
         assert norm(fib.fiber[6:] - np.array([0, np.sin(-a), np.cos(-a)])) < tol
@@ -94,7 +95,7 @@ def test_lv_angles():
 
     for alpha in [30, 40, 50, -30, -40, -50]:
         a = np.radians(alpha)
-        fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=alpha, alpha_epi_lv=-alpha, **data)
+        fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=alpha, alpha_epi_lv=-alpha, beta_endo_lv=0, beta_epi_lv=0,**data)
         assert norm(fib.fiber[:3] - np.array([0, np.sin(a), np.cos(a)])) < tol
         assert norm(fib.fiber[6:] - np.array([0, np.sin(-a), np.cos(-a)])) < tol
 
@@ -103,6 +104,58 @@ def test_lv_angles():
         assert norm(fib.sheet[:3] - np.cross(fib.sheet_normal[:3], fib.fiber[:3])) < tol
         assert norm(fib.sheet[3:6] - np.cross(fib.sheet_normal[3:6], fib.fiber[3:6])) < tol
         assert norm(fib.sheet[6:] - np.cross(fib.sheet_normal[6:], fib.fiber[6:])) < tol
+
+
+
+def test_lv_angles_beta():
+
+    data = {}
+    eps = 0
+    tol = 1e-12
+    data['lv_scalar']= np.array([1.0, 0.5, eps])
+    data['lv_gradient'] = np.zeros(3 * len(data['lv_scalar']))
+    data['lv_gradient'][::3] = 1.0
+    
+    data['epi_scalar'] = np.flipud(data['lv_scalar'])
+    data['epi_gradient'] = -1 * data['lv_gradient']
+
+    data['apex_gradient'] = np.zeros_like(data['lv_gradient'])
+    data['apex_gradient'][1::3] = 1.0
+
+    sheet_normal = np.array([0, 1, 0, -1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0, -1, 0])
+    fiber = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+
+    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=0, alpha_epi_lv=0, beta_endo_lv=90, beta_epi_lv=-90, **data)
+    
+    assert np.linalg.norm(fib.fiber - fiber) < tol
+    assert norm(fib.sheet[:3] - np.array([1, 0, 0])) < tol
+    assert norm(fib.sheet[3:6]-np.array([1 / np.sqrt(2), 1 / np.sqrt(2), 0])) < tol
+    assert norm(fib.sheet[6:] - np.array([-1, 0, 0])) < tol
+    assert norm(fib.sheet_normal - sheet_normal) < tol
+
+    fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=0, alpha_epi_lv=0, beta_endo_lv=-90, beta_epi_lv=90, **data)
+    
+    assert np.linalg.norm(fib.fiber - fiber) < tol
+    assert norm(fib.sheet[:3] - np.array([-1, 0, 0])) < tol
+    assert norm(fib.sheet[3:6]-np.array([-1 / np.sqrt(2), 1 / np.sqrt(2), 0])) < tol
+    assert norm(fib.sheet[6:] - np.array([1, 0, 0])) < tol
+    sheet_normal *= -1
+    sheet_normal[3] = -1 / np.sqrt(2)
+    assert norm(fib.sheet_normal - sheet_normal) < tol
+
+    for beta in [30, 40, 50, -30, -40, -50]:
+        a = np.radians(beta)
+        fib = ldrb.ldrb.compute_fiber_sheet_system(alpha_endo_lv=0, alpha_epi_lv=-0, beta_endo_lv=beta, beta_epi_lv=beta,**data)
+        assert np.linalg.norm(fib.fiber - fiber) < tol
+
+        assert norm(fib.sheet[:3] - np.array([np.sin(a), np.cos(a), 0])) < tol
+        assert norm(fib.sheet[3:6] - np.array([np.sin(a), np.cos(a), 0])) < tol
+        assert norm(fib.sheet[6:] - np.array([np.sin(a), np.cos(a), 0])) < tol
+
+        assert norm(fib.sheet_normal[:3] - np.cross(fib.fiber[:3], fib.sheet[:3])) < tol
+        assert norm(fib.sheet_normal[3:6] - np.cross(fib.fiber[3:6], fib.sheet[3:6])) < tol
+        assert norm(fib.sheet_normal[6:] - np.cross(fib.fiber[6:], fib.sheet[6:])) < tol
+
 
 
 @pytest.mark.parametrize("fiber_space", fiber_spaces)


### PR DESCRIPTION
Trying different value of the beta parameter for the sheet angle results in the same sheet field. This indicates that there is a bug in the code. This PR fixes this. The error was caused by a misuse to `numpy.dot` function in the `orient` method. 