### PR TITLE
Configurable convergence criteria for Krylov solvers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,18 +34,6 @@ jobs:
           python3 -m pip install h5py --no-binary=h5py
           python3 -m pip install -e ".[test]"
 
-      - name: Run flake8
-        run: |
-          python3 -m flake8 ldrb tests
-
-      - name: Run black
-        run: |
-          python3 -m black --check ldrb tests
-
-      - name: Run mypy
-        run: |
-          python3 -m mypy ldrb tests
-
       - name: Test with pytest
         run: |
           python3 -m pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-yaml
         exclude: conda.recipe/meta.yaml
@@ -10,13 +10,13 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v2.7.1
     hooks:
       - id: reorder-python-imports
         exclude: ^demos/
 
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.1.0
     hooks:
       - id: black
 
@@ -26,16 +26,16 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: add-trailing-comma
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.931
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,4 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
+        exclude: ^demos/

--- a/ldrb/ldrb.py
+++ b/ldrb/ldrb.py
@@ -20,6 +20,9 @@ def laplace(
     fiber_space: str = "CG_1",
     ffun: Optional[df.MeshFunction] = None,
     use_krylov_solver: bool = False,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
     verbose: bool = False,
     strict: bool = False,
 ) -> Dict[str, np.ndarray]:
@@ -35,6 +38,9 @@ def laplace(
         markers=markers,
         ffun=ffun,
         use_krylov_solver=use_krylov_solver,
+        krylov_solver_atol=krylov_solver_atol,
+        krylov_solver_rtol=krylov_solver_rtol,
+        krylov_solver_max_its=krylov_solver_max_its,
         verbose=verbose,
         strict=strict,
     )
@@ -226,6 +232,9 @@ def dolfin_ldrb(
     markers: Optional[Dict[str, int]] = None,
     log_level: int = logging.INFO,
     use_krylov_solver: bool = False,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
     strict: bool = False,
     save_markers: bool = False,
     alpha_endo_lv: float = 40,
@@ -270,6 +279,17 @@ def dolfin_ldrb(
         Default: INFO
     use_krylov_solver: bool
         If True use Krylov solver, by default False
+    krylov_solver_atol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the absolute
+        residual. Default: 1e-15.
+    krylov_solver_rtol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the relative
+        residual. Default: 1e-10.
+    krylov_solver_max_its: int (optional)
+        If a Krylov solver is used, this option specifies the
+        maximum number of iterations to perform. Default: 10000.
     strict: bool
         If true raise RuntimeError if solutions does not sum to 1.0
     save_markers: bool
@@ -334,6 +354,9 @@ def dolfin_ldrb(
         markers=markers,
         ffun=ffun,
         use_krylov_solver=use_krylov_solver,
+        krylov_solver_atol=krylov_solver_atol,
+        krylov_solver_rtol=krylov_solver_rtol,
+        krylov_solver_max_its=krylov_solver_max_its,
         verbose=verbose,
         strict=strict,
     )
@@ -403,6 +426,9 @@ def apex_to_base(
     base_marker: int,
     ffun: df.MeshFunction,
     use_krylov_solver: bool = False,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
     verbose: bool = False,
 ):
     """
@@ -421,6 +447,17 @@ def apex_to_base(
         be used.
     use_krylov_solver: bool
         If True use Krylov solver, by default False
+    krylov_solver_atol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the absolute
+        residual. Default: 1e-15.
+    krylov_solver_rtol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the relative
+        residual. Default: 1e-10.
+    krylov_solver_max_its: int (optional)
+        If a Krylov solver is used, this option specifies the
+        maximum number of iterations to perform. Default: 10000.
     verbose: bool
         If true, print more info, by default False
     """
@@ -446,6 +483,9 @@ def apex_to_base(
         apex,
         solver_parameters={"linear_solver": "cg", "preconditioner": "amg"},
         use_krylov_solver=use_krylov_solver,
+        krylov_solver_atol=krylov_solver_atol,
+        krylov_solver_rtol=krylov_solver_rtol,
+        krylov_solver_max_its=krylov_solver_max_its,
         verbose=verbose,
     )
 
@@ -492,6 +532,9 @@ def apex_to_base(
             bcs,
             apex,
             use_krylov_solver=use_krylov_solver,
+            krylov_solver_atol=krylov_solver_atol,
+            krylov_solver_rtol=krylov_solver_rtol,
+            krylov_solver_max_its=krylov_solver_max_its,
             solver_parameters={"linear_solver": "gmres"},
             verbose=verbose,
         )
@@ -547,6 +590,9 @@ def scalar_laplacians(
     markers: Optional[Dict[str, int]] = None,
     ffun: Optional[MeshFunction] = None,
     use_krylov_solver: bool = False,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
     verbose: bool = False,
     strict: bool = False,
 ) -> Dict[str, df.Function]:
@@ -570,6 +616,17 @@ def scalar_laplacians(
         determines for what space the fibers should be calculated for.
     use_krylov_solver: bool
         If True use Krylov solver, by default False
+    krylov_solver_atol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the absolute
+        residual. Default: 1e-15.
+    krylov_solver_rtol: float (optional)
+        If a Krylov solver is used, this option specifies a
+        convergence criterion in terms of the relative
+        residual. Default: 1e-10.
+    krylov_solver_max_its: int (optional)
+        If a Krylov solver is used, this option specifies the
+        maximum number of iterations to perform. Default: 10000.
     verbose: bool
         If true, print more info, by default False
     strict: bool
@@ -617,6 +674,9 @@ def scalar_laplacians(
         verbose=verbose,
         use_krylov_solver=use_krylov_solver,
         strict=strict,
+        krylov_solver_atol=krylov_solver_atol,
+        krylov_solver_rtol=krylov_solver_rtol,
+        krylov_solver_max_its=krylov_solver_max_its,
     )
 
 
@@ -675,6 +735,9 @@ def bayer(
     verbose: bool,
     use_krylov_solver: bool,
     strict: bool,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
 ) -> Dict[str, df.Function]:
 
     apex = apex_to_base(
@@ -682,6 +745,9 @@ def bayer(
         markers["base"],
         ffun,
         use_krylov_solver=use_krylov_solver,
+        krylov_solver_atol=krylov_solver_atol,
+        krylov_solver_rtol=krylov_solver_rtol,
+        krylov_solver_max_its=krylov_solver_max_its,
         verbose=verbose,
     )
 
@@ -730,6 +796,9 @@ def bayer(
             solutions[case],
             solver_parameters=solver_parameters,
             use_krylov_solver=use_krylov_solver,
+            krylov_solver_atol=krylov_solver_atol,
+            krylov_solver_rtol=krylov_solver_rtol,
+            krylov_solver_max_its=krylov_solver_max_its,
             verbose=verbose,
         )
 
@@ -763,6 +832,9 @@ def bayer(
             solutions["lv_rv"],
             solver_parameters=solver_parameters,
             use_krylov_solver=use_krylov_solver,
+            krylov_solver_atol=krylov_solver_atol,
+            krylov_solver_rtol=krylov_solver_rtol,
+            krylov_solver_max_its=krylov_solver_max_its,
             verbose=verbose,
         )
 
@@ -784,8 +856,8 @@ def solve_krylov(
     verbose: bool = False,
     ksp_type="cg",
     ksp_norm_type="unpreconditioned",
-    ksp_rtol=1e-10,
     ksp_atol=1e-15,
+    ksp_rtol=1e-10,
     ksp_max_it=10000,
     ksp_error_if_not_converged=False,
     pc_type="hypre",
@@ -799,8 +871,8 @@ def solve_krylov(
     solver = df.PETScKrylovSolver()
     df.PETScOptions.set("ksp_type", ksp_type)
     df.PETScOptions.set("ksp_norm_type", ksp_norm_type)
-    df.PETScOptions.set("ksp_rtol", ksp_rtol)
     df.PETScOptions.set("ksp_atol", ksp_atol)
+    df.PETScOptions.set("ksp_rtol", ksp_rtol)
     df.PETScOptions.set("ksp_max_it", ksp_max_it)
     df.PETScOptions.set("ksp_error_if_not_converged", ksp_error_if_not_converged)
     if ksp_monitor:
@@ -833,11 +905,19 @@ def solve_system(
     u: df.Function,
     solver_parameters: Optional[Dict[str, str]] = None,
     use_krylov_solver: bool = False,
+    krylov_solver_atol: Optional[float] = None,
+    krylov_solver_rtol: Optional[float] = None,
+    krylov_solver_max_its: Optional[int] = None,
     verbose: bool = False,
 ) -> Optional[df.PETScKrylovSolver]:
     if use_krylov_solver:
         try:
-            return solve_krylov(a, L, bcs, u, verbose)
+            return solve_krylov(
+                a, L, bcs, u,
+                ksp_atol=krylov_solver_atol,
+                ksp_rtol=krylov_solver_rtol,
+                ksp_max_it=krylov_solver_max_its,
+                verbose=verbose)
         except Exception:
             df.info("Failed to solve using Krylov solver. Try a regular solve...")
             solve_regular(a, L, bcs, u, solver_parameters)

--- a/ldrb/ldrb.py
+++ b/ldrb/ldrb.py
@@ -918,11 +918,15 @@ def solve_system(
     if use_krylov_solver:
         try:
             return solve_krylov(
-                a, L, bcs, u,
+                a,
+                L,
+                bcs,
+                u,
                 ksp_atol=krylov_solver_atol,
                 ksp_rtol=krylov_solver_rtol,
                 ksp_max_it=krylov_solver_max_its,
-                verbose=verbose)
+                verbose=verbose,
+            )
         except Exception:
             df.info("Failed to solve using Krylov solver. Try a regular solve...")
             solve_regular(a, L, bcs, u, solver_parameters)

--- a/ldrb/ldrb.py
+++ b/ldrb/ldrb.py
@@ -658,8 +658,13 @@ def scalar_laplacians(
     )
 
     # Compte the apex to base solutons
-    df.info("  Num coords: {0}".format(mesh.num_vertices()))
-    df.info("  Num cells: {0}".format(mesh.num_cells()))
+    num_vertices = mesh.num_vertices()
+    num_cells = mesh.num_cells()
+    if mesh.mpi_comm().size > 1:
+        num_vertices = mesh.mpi_comm().allreduce(num_vertices)
+        num_cells = mesh.mpi_comm().allreduce(num_cells)
+    df.info("  Num vertices: {0}".format(num_vertices))
+    df.info("  Num cells: {0}".format(num_cells))
 
     if "mv" in cases and "av" in cases:
         # Use Doste approach

--- a/ldrb/utils.py
+++ b/ldrb/utils.py
@@ -13,7 +13,7 @@ import ufl
 try:
     import mshr
 except ImportError:
-    df.debug("mshr is not installed")
+    df.warning("mshr is not installed")
 
 
 def has_meshio() -> bool:

--- a/ldrb/utils.py
+++ b/ldrb/utils.py
@@ -176,7 +176,7 @@ def mark_facets(mesh: df.Mesh, ffun: df.MeshFunction):
     """
     for facet in df.facets(mesh):
 
-        if ffun[facet] == 2 ** 64 - 1:
+        if ffun[facet] == 2**64 - 1:
             ffun[facet] = 0
 
         mesh.domains().set_marker((facet.index(), ffun[facet]), 2)
@@ -228,11 +228,11 @@ def create_lv_mesh(
 
     class Endo(df.SubDomain):
         def inside(self, x, on_boundary):
-            return (x[0] - center.x()) ** 2 / a_endo ** 2 + (
+            return (x[0] - center.x()) ** 2 / a_endo**2 + (
                 x[1] - center.y()
-            ) ** 2 / b_endo ** 2 + (
+            ) ** 2 / b_endo**2 + (
                 x[2] - center.z()
-            ) ** 2 / c_endo ** 2 - 1.1 < df.DOLFIN_EPS and on_boundary
+            ) ** 2 / c_endo**2 - 1.1 < df.DOLFIN_EPS and on_boundary
 
     class Base(df.SubDomain):
         def inside(self, x, on_boundary):
@@ -240,11 +240,11 @@ def create_lv_mesh(
 
     class Epi(df.SubDomain):
         def inside(self, x, on_boundary):
-            return (x[0] - center.x()) ** 2 / a_epi ** 2 + (
+            return (x[0] - center.x()) ** 2 / a_epi**2 + (
                 x[1] - center.y()
-            ) ** 2 / b_epi ** 2 + (
+            ) ** 2 / b_epi**2 + (
                 x[2] - center.z()
-            ) ** 2 / c_epi ** 2 - 0.9 > df.DOLFIN_EPS and on_boundary
+            ) ** 2 / c_epi**2 - 0.9 > df.DOLFIN_EPS and on_boundary
 
     # The plane cutting the base
     diam = -2 * a_epi
@@ -328,11 +328,11 @@ def create_biv_mesh(
 
     class EndoLV(df.SubDomain):
         def inside(self, x, on_boundary):
-            return (x[0] - center_lv.x()) ** 2 / a_endo_lv ** 2 + (
+            return (x[0] - center_lv.x()) ** 2 / a_endo_lv**2 + (
                 x[1] - center_lv.y()
-            ) ** 2 / b_endo_lv ** 2 + (
+            ) ** 2 / b_endo_lv**2 + (
                 x[2] - center_lv.z()
-            ) ** 2 / c_endo_lv ** 2 - 1 < df.DOLFIN_EPS and on_boundary
+            ) ** 2 / c_endo_lv**2 - 1 < df.DOLFIN_EPS and on_boundary
 
     class Base(df.SubDomain):
         def inside(self, x, on_boundary):
@@ -341,14 +341,14 @@ def create_biv_mesh(
     class EndoRV(df.SubDomain):
         def inside(self, x, on_boundary):
             return (
-                (x[0] - center_rv.x()) ** 2 / a_endo_rv ** 2
-                + (x[1] - center_rv.y()) ** 2 / b_endo_rv ** 2
-                + (x[2] - center_rv.z()) ** 2 / c_endo_rv ** 2
+                (x[0] - center_rv.x()) ** 2 / a_endo_rv**2
+                + (x[1] - center_rv.y()) ** 2 / b_endo_rv**2
+                + (x[2] - center_rv.z()) ** 2 / c_endo_rv**2
                 - 1
                 < df.DOLFIN_EPS
-                and (x[0] - center_lv.x()) ** 2 / a_epi_lv ** 2
-                + (x[1] - center_lv.y()) ** 2 / b_epi_lv ** 2
-                + (x[2] - center_lv.z()) ** 2 / c_epi_lv ** 2
+                and (x[0] - center_lv.x()) ** 2 / a_epi_lv**2
+                + (x[1] - center_lv.y()) ** 2 / b_epi_lv**2
+                + (x[2] - center_lv.z()) ** 2 / c_epi_lv**2
                 - 0.9
                 > df.DOLFIN_EPS
             ) and on_boundary
@@ -356,14 +356,14 @@ def create_biv_mesh(
     class Epi(df.SubDomain):
         def inside(self, x, on_boundary):
             return (
-                (x[0] - center_rv.x()) ** 2 / a_epi_rv ** 2
-                + (x[1] - center_rv.y()) ** 2 / b_epi_rv ** 2
-                + (x[2] - center_rv.z()) ** 2 / c_epi_rv ** 2
+                (x[0] - center_rv.x()) ** 2 / a_epi_rv**2
+                + (x[1] - center_rv.y()) ** 2 / b_epi_rv**2
+                + (x[2] - center_rv.z()) ** 2 / c_epi_rv**2
                 - 0.9
                 > df.DOLFIN_EPS
-                and (x[0] - center_lv.x()) ** 2 / a_epi_lv ** 2
-                + (x[1] - center_lv.y()) ** 2 / b_epi_lv ** 2
-                + (x[2] - center_lv.z()) ** 2 / c_epi_lv ** 2
+                and (x[0] - center_lv.x()) ** 2 / a_epi_lv**2
+                + (x[1] - center_lv.y()) ** 2 / b_epi_lv**2
+                + (x[2] - center_lv.z()) ** 2 / c_epi_lv**2
                 - 0.9
                 > df.DOLFIN_EPS
                 and on_boundary

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords = cardiac modeling, fiber orientations
 
 [options]


### PR DESCRIPTION
This pull request adds a few options to control the convergence criteria in cases where a Krylov solver is used.

There are also some minor fixes related to diagnostic output. For instance, the `scalar_laplacian` function now prints the total number of vertices and cells in a mesh when using MPI, instead of the per-process number. I believe that in most cases, it is the total number that is most interesting.