### PR TITLE
Add scipy as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     h5py
     numba
     numpy
+    scipy
 python_requires = >=3.6
 zip_safe = False
 


### PR DESCRIPTION
Fixes https://github.com/finsberg/ldrb/issues/24

According to the [numba docs](https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#linear-algebra) `numpy.dot` requires `scipy` to be installed. Since this is used in e.g https://github.com/finsberg/ldrb/blob/16e93e26c4b4edbef9abe7d11da27aa4a53a5171/ldrb/calculus.py#L317 we need to also add scipy as a dependency