### PR TITLE
Fix wrong "dot" product.

### DIFF
--- a/ldrb/calculus.py
+++ b/ldrb/calculus.py
@@ -42,7 +42,7 @@ def bislerp(
         -quat_k * qa,
     ]
 
-    dot_arr = [np.linalg.norm((qm*qb).components) for qm in quat_array]
+    dot_arr = [np.linalg.norm((qm * qb).components) for qm in quat_array]
     max_idx = int(np.argmax(dot_arr))
     max_dot = dot_arr[max_idx]
     qm = quat_array[max_idx]

--- a/ldrb/calculus.py
+++ b/ldrb/calculus.py
@@ -42,7 +42,7 @@ def bislerp(
         -quat_k * qa,
     ]
 
-    dot_arr = [abs((qi.components * qb.components).sum()) for qi in quat_array]
+    dot_arr = [np.linalg.norm((qm*qb).components) for qm in quat_array]
     max_idx = int(np.argmax(dot_arr))
     max_dot = dot_arr[max_idx]
     qm = quat_array[max_idx]


### PR DESCRIPTION
Following on from #43 I think there is one more mistake in how the quaternion that minimizes the rotation angle between $Q_A$ and $Q_B$ is chosen. Again, line 3 in the supplementary material of Bayer et. al. says the following:
> Find $q_M \in \\{ \pm q_A, \pm i \cdot q_A, \pm j \cdot q_A, \pm k \cdot q_A \\}$ that maximizes $\\| q_M \cdot q_B \\|$

I think that $q_M \cdot q_B$, just like with the products between the unit quaternion and $q_A$, is supposed to be a quaternion (Hamilton) product, rather than a vector dot product. Followingly, the length $\\| \ldots \\|$ is not an absolute value of a scalar, but rather the norm of the quaternion $q = q_M \cdot q_B$. But, I am not 100% sure of this. For example, I see that the implementation of `bislerp`  in cardioid (https://github.com/LLNL/cardioid/blob/59c07b714d8b066b4f84eb50487c36f6eadf634c/fibers/genfiber.cpp) also uses a vector dot product rather than a quaternion product.

I have not verified this, but I think this might be the cause of the problem #29.


